### PR TITLE
script to auto set java version in gradle properties

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -7,7 +7,7 @@ cd "${BASEDIR}"
 
 #--------------------------------------------------------------------------
 #
-# Set Colors
+# Set Colours
 #
 #--------------------------------------------------------------------------
 bold=$(tput bold)
@@ -62,7 +62,7 @@ function update_gradle_proprties_java_version {
     if [ -f "$properties_file" ]; then
         echo "Path to gradle.properties file found."
 
-        sed -i -e "s/^java_version.*/java_version=${local_java}/" $properties_file
+        sed -i "" -e "s/^java_version.*/java_version=${local_java}/" $properties_file
 
         rc=$?
         if [[ "${rc}" != "0" ]]; then


### PR DESCRIPTION
Currently, users have to have the knowledge of their current java version and ensure it corresponds to the version set in the gradle.properties file. upon initial cloning this is set to 8. however if a user has 11 installed, running this script should change the property for them and perform maven/gradle builds with no extra knowledge or effort